### PR TITLE
Feat: add device id to job list

### DIFF
--- a/src/backend/hook.ts
+++ b/src/backend/hook.ts
@@ -20,7 +20,7 @@ export const useJobAPI = () => {
   const getLatestJobs = async (page: number, pageSize: number): Promise<Job[]> => {
     return api.job
       .listJobs(
-        'job_id,name,description,device_id,job_info,transpiler_info,simulator_info,mitigation_info,job_type,shots,status',
+        'job_id,name,description,device_id,job_info,transpiler_info,simulator_info,mitigation_info,job_type,shots,status,submitted_at',
         undefined,
         undefined,
         undefined,

--- a/src/i18n/en/dashboard.ts
+++ b/src/i18n/en/dashboard.ts
@@ -20,6 +20,7 @@ export default {
     button: 'View Jobs',
     table: {
       id: 'Job ID',
+      device: 'Device Name',
       status: 'Status',
       date: 'Created',
       shots: 'Shots',

--- a/src/i18n/en/dashboard.ts
+++ b/src/i18n/en/dashboard.ts
@@ -9,7 +9,7 @@ export default {
     title: 'Device',
     button: 'View Devices',
     table: {
-      name: 'Name',
+      name: 'Device ID',
       status: 'Status',
       qubits: 'Number of qubits',
       type: 'Type',
@@ -20,7 +20,7 @@ export default {
     button: 'View Jobs',
     table: {
       id: 'Job ID',
-      device: 'Device Name',
+      device: 'Device ID',
       status: 'Status',
       date: 'Created',
       shots: 'Shots',

--- a/src/i18n/en/device.ts
+++ b/src/i18n/en/device.ts
@@ -54,6 +54,7 @@ export default {
         error: 'read allocation error',
       },
     },
+    not_found: 'Device not found.',
   },
   status: {
     available: 'Available',

--- a/src/i18n/en/job.ts
+++ b/src/i18n/en/job.ts
@@ -14,6 +14,7 @@ export default {
     },
     table: {
       id: 'Job ID',
+      device: 'Device Name',
       status: 'Status',
       date: 'Created',
       description: 'Description',

--- a/src/i18n/en/job.ts
+++ b/src/i18n/en/job.ts
@@ -14,7 +14,7 @@ export default {
     },
     table: {
       id: 'Job ID',
-      device: 'Device Name',
+      device: 'Device ID',
       status: 'Status',
       date: 'Created',
       description: 'Description',

--- a/src/i18n/ja/dashboard.ts
+++ b/src/i18n/ja/dashboard.ts
@@ -9,7 +9,7 @@ export default {
     title: 'デバイス',
     button: '一覧へ',
     table: {
-      name: 'デバイス名',
+      name: 'デバイスID',
       status: 'ステータス',
       qubits: '量子ビット数',
       type: 'タイプ',
@@ -20,7 +20,7 @@ export default {
     button: '一覧へ',
     table: {
       id: 'ジョブID',
-      device: 'デバイス名',
+      device: 'デバイスID',
       status: 'ステータス',
       date: '登録日時',
       shots: 'ショット数',

--- a/src/i18n/ja/dashboard.ts
+++ b/src/i18n/ja/dashboard.ts
@@ -20,6 +20,7 @@ export default {
     button: '一覧へ',
     table: {
       id: 'ジョブID',
+      device: 'デバイス名',
       status: 'ステータス',
       date: '登録日時',
       shots: 'ショット数',

--- a/src/i18n/ja/device.ts
+++ b/src/i18n/ja/device.ts
@@ -54,6 +54,7 @@ export default {
         error: '読み出し割り当てエラー',
       },
     },
+    not_found: '対象のデバイスが存在しません',
   },
   status: {
     available: '利用可',

--- a/src/i18n/ja/job.ts
+++ b/src/i18n/ja/job.ts
@@ -14,6 +14,7 @@ export default {
     },
     table: {
       id: 'ジョブID',
+      device: 'デバイス名',
       status: 'ステータス',
       date: '登録日時',
       description: '説明',

--- a/src/i18n/ja/job.ts
+++ b/src/i18n/ja/job.ts
@@ -14,7 +14,7 @@ export default {
     },
     table: {
       id: 'ジョブID',
-      device: 'デバイス名',
+      device: 'デバイスID',
       status: 'ステータス',
       date: '登録日時',
       description: '説明',

--- a/src/pages/authenticated/dashboard/_components/JobList.tsx
+++ b/src/pages/authenticated/dashboard/_components/JobList.tsx
@@ -24,7 +24,7 @@ export const JobList = ({ jobs }: { jobs: Job[] }): React.ReactElement => {
         <thead>
           <tr>
             <th className="!w-[400px]">{t('dashboard.job.table.id')}</th>
-            <th>{t('dashboard.job.table.device')}</th>
+            <th className="!w-[400px]">{t('dashboard.job.table.device')}</th>
             <th className="!w-[50px]">{t('dashboard.job.table.status')}</th>
             <th className="!w-[160px]">{t('dashboard.job.table.date')}</th>
             <th className="!w-[80px]">{t('dashboard.job.table.shots')}</th>
@@ -40,7 +40,11 @@ export const JobList = ({ jobs }: { jobs: Job[] }): React.ReactElement => {
                     {job.id}
                   </NavLink>
                 </td>
-                <td>{job.deviceId}</td>
+                <td>
+                  <NavLink to={`/device/${job.deviceId}`} className="text-link">
+                    {job.deviceId}
+                  </NavLink>
+                </td>
                 <td>
                   <JobStatus status={job.status} />
                 </td>

--- a/src/pages/authenticated/dashboard/_components/JobList.tsx
+++ b/src/pages/authenticated/dashboard/_components/JobList.tsx
@@ -24,6 +24,7 @@ export const JobList = ({ jobs }: { jobs: Job[] }): React.ReactElement => {
         <thead>
           <tr>
             <th className="!w-[400px]">{t('dashboard.job.table.id')}</th>
+            <th>{t('dashboard.job.table.device')}</th>
             <th className="!w-[50px]">{t('dashboard.job.table.status')}</th>
             <th className="!w-[160px]">{t('dashboard.job.table.date')}</th>
             <th className="!w-[80px]">{t('dashboard.job.table.shots')}</th>
@@ -39,6 +40,7 @@ export const JobList = ({ jobs }: { jobs: Job[] }): React.ReactElement => {
                     {job.id}
                   </NavLink>
                 </td>
+                <td>{job.deviceId}</td>
                 <td>
                   <JobStatus status={job.status} />
                 </td>

--- a/src/pages/authenticated/device/detail/page.tsx
+++ b/src/pages/authenticated/device/detail/page.tsx
@@ -83,7 +83,7 @@ const NotFoundView = () => {
     <>
       <Title />
       <Spacer className="h-3" />
-      <p className={clsx('text-error', 'text-xs')}>{t('job.detail.not_found')}</p>
+      <p className={clsx('text-error', 'text-xs')}>{t('device.detail.not_found')}</p>
     </>
   );
 };

--- a/src/pages/authenticated/jobs/_components/JobListItem.tsx
+++ b/src/pages/authenticated/jobs/_components/JobListItem.tsx
@@ -62,6 +62,7 @@ export const JobListItem = ({ job, onJobModified }: JobProps) => {
           {job.id}
         </NavLink>
       </td>
+      <td>{job.deviceId}</td>
       <td>
         <JobStatus status={job.status} />
       </td>

--- a/src/pages/authenticated/jobs/_components/JobListItem.tsx
+++ b/src/pages/authenticated/jobs/_components/JobListItem.tsx
@@ -62,7 +62,11 @@ export const JobListItem = ({ job, onJobModified }: JobProps) => {
           {job.id}
         </NavLink>
       </td>
-      <td>{job.deviceId}</td>
+      <td>
+        <NavLink to={`/device/${job.deviceId}`} className="text-link">
+          {job.deviceId}
+        </NavLink>
+      </td>
       <td>
         <JobStatus status={job.status} />
       </td>

--- a/src/pages/authenticated/jobs/page.tsx
+++ b/src/pages/authenticated/jobs/page.tsx
@@ -102,6 +102,7 @@ export default function JobListPage() {
               <thead>
                 <tr>
                   <th>{t('job.list.table.id')}</th>
+                  <th>{t('job.list.table.device')}</th>
                   <th>{t('job.list.table.status')}</th>
                   <th>{t('job.list.table.date')}</th>
                   <th className={clsx('w-full')}>{t('job.list.table.description')}</th>


### PR DESCRIPTION
I have resolved Issue [#4](https://github.com/oqtopus-team/oqtopus-frontend/issues/4).
Device names are displayed for each job on the dashboard and jobs page.

In addition, I slightly modified to display “Created" value.