### PR TITLE
Modify the fontsize of error message and the topology label in the device detail page

### DIFF
--- a/src/pages/authenticated/device/detail/_components/TopologyInfo.tsx
+++ b/src/pages/authenticated/device/detail/_components/TopologyInfo.tsx
@@ -59,7 +59,7 @@ const createNodeData = (qubits: any[]): { nodeData: any[]; tempNodeMap: Map<stri
       tempNodeMap.set(qubit.id.toString(), qubit);
       return {
         id: qubit.id.toString(),
-        label: `Q${qubit.id}`,
+        label: `${qubit.id}`,
         fx: scalePosition(qubit.position.x),
         fy: scalePosition(qubit.position.y * -1), // multiply by -1 to flip the y-axis
       };
@@ -232,7 +232,7 @@ export const TopologyInfo: React.FC<{ deviceInfo: string | undefined }> = ({ dev
 
   if (!isValidDeviceInfo) {
     return (
-      <p className={clsx('text-error', 'text-xs')}>
+      <p className={clsx('text-error', 'text-xl')}>
         {t('device.detail.topology_info.invalid_device_info')}
       </p>
     );


### PR DESCRIPTION
# Ticket
* https://github.com/oqtopus-team/oqtopus-frontend/issues/55
# Description
### Fontsize
enlarged the fontsize of the error message displayed in case of QPU
![image](https://github.com/user-attachments/assets/b3c107e0-3c18-426e-a92a-4b556cdd5dab)

### Topology label
removed "Q" in the topology view
![image](https://github.com/user-attachments/assets/6b9e3955-7bfa-4439-b817-d00d5a57d3f7)
