### PR TITLE
feat: add TruncateText component and integrate it into JobList and Jo…

### DIFF
--- a/src/pages/authenticated/_components/TruncateText.tsx
+++ b/src/pages/authenticated/_components/TruncateText.tsx
@@ -1,0 +1,15 @@
+import { FC } from 'react';
+import clsx from 'clsx';
+
+export type TruncateTextProps = {
+  text: string;
+  limit: number;
+  className?: string;
+};
+
+export const TruncateText: FC<TruncateTextProps> = ({ text, limit, className }) => {
+  const displayText = text.length > limit ? `${text.slice(0, limit)}…` : text;
+  return <span className={clsx('break-words', className)}>{displayText}</span>;
+};
+
+export default TruncateText;

--- a/src/pages/authenticated/dashboard/_components/JobList.tsx
+++ b/src/pages/authenticated/dashboard/_components/JobList.tsx
@@ -6,6 +6,7 @@ import clsx from 'clsx';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router';
 import { DateTimeFormatter } from '@/pages/authenticated/_components/DateTimeFormatter';
+import { TruncateText } from '@/pages/authenticated/_components/TruncateText';
 
 export const JobList = ({ jobs }: { jobs: Job[] }): React.ReactElement => {
   const { t, i18n } = useTranslation();
@@ -42,7 +43,10 @@ export const JobList = ({ jobs }: { jobs: Job[] }): React.ReactElement => {
                     {job.id}
                   </NavLink>
                 </td>
-                <td>{job.name}</td>
+                <td>
+                  {/* limit the length to display to twice the length of the job.id */}
+                  <TruncateText text={job.name} limit={job.id.length * 2} />
+                </td>
                 <td>
                   <NavLink to={`/device/${job.deviceId}`} className="text-link">
                     {job.deviceId}

--- a/src/pages/authenticated/jobs/_components/JobListItem.tsx
+++ b/src/pages/authenticated/jobs/_components/JobListItem.tsx
@@ -9,6 +9,7 @@ import { NavLink } from 'react-router';
 import { useJobAPI } from '@/backend/hook';
 import { DateTimeFormatter } from '../../_components/DateTimeFormatter';
 import DownloadJobButton from './DownloadJobButton';
+import { TruncateText } from '@/pages/authenticated/_components/TruncateText';
 
 interface JobProps {
   job: Job;
@@ -78,7 +79,10 @@ export const JobListItem = ({
           {job.id}
         </NavLink>
       </td>
-      <td>{job.name}</td>
+      <td>
+        {/* limit the length to display to twice the length of the job.id */}
+        <TruncateText text={job.name} limit={job.id.length * 2} />
+      </td>
       <td>
         <NavLink to={`/device/${job.deviceId}`} className="text-link">
           {job.deviceId}

--- a/src/pages/authenticated/jobs/detail/_components/panels/JobDetailBasicInfo.tsx
+++ b/src/pages/authenticated/jobs/detail/_components/panels/JobDetailBasicInfo.tsx
@@ -62,7 +62,7 @@ export const JobDetailBasicInfo: React.FC<JobDetailBasicInfoProps> = (
           </tr>
           <tr>
             <BoldTh>{t('job.detail.info.name')}</BoldTh>
-            <td>{job.name}</td>
+            <td className={clsx('whitespace-normal', 'break-words', 'max-w-sm')}>{job.name}</td>
           </tr>
           <tr>
             <BoldTh>{t('job.detail.info.description')}</BoldTh>


### PR DESCRIPTION
# Ticket
* https://github.com/oqtopus-team/oqtopus-frontend/issues/53
# Description
### Dashboard
Limit the length to display.
![image](https://github.com/user-attachments/assets/f35eb8eb-97ba-4c8e-b14c-764a981b537c)

### Job List
Limit the length to display like Dashboard.
![image](https://github.com/user-attachments/assets/632a2cd8-a721-4c2e-b8f2-62b84c46a087)

## Job Detail
The length of the string itself is not limited, but the width is collapsed.
![image](https://github.com/user-attachments/assets/805163dd-a834-45ae-aaa8-d83e3d8877c9)

