### PR TITLE
fix: return filtered categories in reshapeToHistogramInfo function

### DIFF
--- a/src/pages/authenticated/jobs/detail/_components/panels/utils/ReshapeToHistogramInfo.tsx
+++ b/src/pages/authenticated/jobs/detail/_components/panels/utils/ReshapeToHistogramInfo.tsx
@@ -17,5 +17,5 @@ export function reshapeToHistogramInfo(counts: countsProps) {
   const keysList = Object.keys(countsObject).sort();
   const filteredKeys = keysList.filter((key) => countsObject[key] !== 0);
   const valuesList = filteredKeys.map((key) => countsObject[key]);
-  return { categories: keysList, data: valuesList, height: counts.height };
+  return { categories: filteredKeys, data: valuesList, height: counts.height };
 }


### PR DESCRIPTION
# Ticket
* https://github.com/oqtopus-team/oqtopus-frontend/issues/64
# Description
- disabled the zero-count key

The raw data:
```
\"counts\":{\"1011100\":2,\"1100101\":5,\"1101111\":46,\"1110001\":4,\"1110111\":8,\"1111011\":52,\"1111101\":95,\"1111110\":47,\"1111111\":691,\"0110011\":19,\"0100111\":3,\"0111110\":0,\"0111111\":46}
```
## before:
![image](https://github.com/user-attachments/assets/77ab6b23-aeba-40ea-add5-e7080d48636d)
## after
![image](https://github.com/user-attachments/assets/fbe33e85-dad6-4c73-bf81-8cc5e1089365)

