### PR TITLE
refactor: remove descriptions from device, howto, and job list page

### DIFF
--- a/src/i18n/en/device.ts
+++ b/src/i18n/en/device.ts
@@ -1,8 +1,6 @@
 export default {
   list: {
     title: 'Device list',
-    description:
-      'These are electronic components that utilize the knowledge of quantum mechanics, which deals with molecules and atoms. You can check topology information and values ​​for each qubit.',
     table: {
       id: 'Device ID',
       name: 'Device name',

--- a/src/i18n/en/howto.ts
+++ b/src/i18n/en/howto.ts
@@ -1,6 +1,5 @@
 export default {
   title: 'API documentation',
-  description: 'View API specifications.',
   token: {
     head: 'API token',
     none: 'API token not created',

--- a/src/i18n/en/job.ts
+++ b/src/i18n/en/job.ts
@@ -4,7 +4,6 @@ import { toast } from 'react-toastify';
 export default {
   list: {
     title: 'Job',
-    description: 'You can check the list of quantum circuit jobs.',
     register_button: 'Register a new job',
     search: {
       head: 'Job search',

--- a/src/i18n/ja/device.ts
+++ b/src/i18n/ja/device.ts
@@ -1,8 +1,6 @@
 export default {
   list: {
     title: 'デバイス一覧',
-    description:
-      '分子や原子を扱う量子力学の知見を活かした電子部品です。トポロジー情報や量子ビットごとの値などを確認できます。',
     table: {
       id: 'デバイス ID',
       name: 'デバイス名',

--- a/src/i18n/ja/howto.ts
+++ b/src/i18n/ja/howto.ts
@@ -1,6 +1,5 @@
 export default {
   title: 'APIドキュメント',
-  description: 'API仕様を確認できます。',
   token: {
     head: 'API トークン',
     none: 'APIトークンは発行されていません',

--- a/src/i18n/ja/job.ts
+++ b/src/i18n/ja/job.ts
@@ -3,7 +3,6 @@ import { toast } from 'react-toastify';
 export default {
   list: {
     title: 'ジョブ',
-    description: '量子回路のジョブを一覧できます。',
     register_button: '新規でジョブを登録する',
     search: {
       head: 'ジョブ検索',

--- a/src/pages/authenticated/device/page.tsx
+++ b/src/pages/authenticated/device/page.tsx
@@ -31,8 +31,6 @@ export default function Page() {
   return (
     <>
       <h2 className={clsx('text-primary', 'text-2xl', 'font-bold')}>{t('device.list.title')}</h2>
-      <Spacer className="h-3" />
-      <p className={clsx('text-sm')}>{t('device.list.description')}</p>
       <Spacer className="h-8" />
       <Card>
         <DeviceListTable devices={devices} />

--- a/src/pages/authenticated/howto/page.tsx
+++ b/src/pages/authenticated/howto/page.tsx
@@ -12,8 +12,6 @@ export default function Page() {
   return (
     <>
       <h2 className={clsx('text-primary', 'text-2xl', 'font-bold')}>{t('howto.title')}</h2>
-      <Spacer className="h-3" />
-      <p className={clsx('text-sm')}>{t('howto.description')}</p>
       <Spacer className="h-8" />
       <div className={clsx('max-w-[1200px]')}>
         {/* APIトークン */}

--- a/src/pages/authenticated/jobs/page.tsx
+++ b/src/pages/authenticated/jobs/page.tsx
@@ -78,7 +78,7 @@ export default function JobListPage() {
     getLatestJobs(page, PAGE_SIZE, params)
       .then((resJobs) => {
         setJobs(page === 1 ? resJobs : [...jobs, ...resJobs]);
-        // When the response contains items exactly same as the page size, 
+        // When the response contains items exactly same as the page size,
         // it means there are more items to fetch, so we set `hasMore` to true
         if (resJobs.length === PAGE_SIZE) {
           setHasMore(true);
@@ -162,8 +162,6 @@ export default function JobListPage() {
   return (
     <div>
       <h2 className={clsx('text-primary', 'text-2xl', 'font-bold')}>{t('job.list.title')}</h2>
-      <Spacer className="h-3" />
-      <p className={clsx('text-sm')}>{t('job.list.description')}</p>
       <Spacer className="h-8" />
       <div className={clsx('absolute', 'top-8', 'right-8')}>
         <NavLink color="secondary" to={'/jobs/form'}>
@@ -194,9 +192,7 @@ export default function JobListPage() {
           <InfiniteScroll
             next={() => getJobsScroll(page)}
             hasMore={hasMore}
-            loader={<Loadmore  
-              handleClick={() => getJobsScroll(page)}
-            />}
+            loader={<Loadmore handleClick={() => getJobsScroll(page)} />}
             dataLength={jobs.length}
           >
             <table className={clsx('w-full')}>
@@ -292,7 +288,7 @@ export default function JobListPage() {
   );
 }
 
-const Loadmore = (props: { handleClick: () => void}) => {
+const Loadmore = (props: { handleClick: () => void }) => {
   return (
     <div
       className={clsx(
@@ -309,8 +305,8 @@ const Loadmore = (props: { handleClick: () => void}) => {
     >
       Click to load more...
     </div>
-  )
-}
+  );
+};
 
 const generateSearchParams = (params: JobSearchParams): string => {
   const searchParams = new URLSearchParams();


### PR DESCRIPTION
# Ticket
* https://github.com/oqtopus-team/oqtopus-frontend/issues/38
# Description
Deleted the descriptions from
- Device list page
- Job list page
- API documentation page

The description on the Swagger UI part in API documentation page remains the same.
![image](https://github.com/user-attachments/assets/f2e50762-ba5b-4fa4-a5b8-cb91a3e3c5e7)
