### PR TITLE
fix: Update mitigation info key from 'readout' to 'ro_error_mitigation'

### DIFF
--- a/src/domain/types/Job.ts
+++ b/src/domain/types/Job.ts
@@ -67,7 +67,7 @@ export async function initializeJobFormProgramDefaults(): Promise<{
 export const JOB_FORM_MITIGATION_INFO_DEFAULTS: { [key in 'PseudoInv' | 'None']: string } = {
   PseudoInv: JSON.stringify(
     {
-      readout: 'pseudo_inverse',
+      ro_error_mitigation: 'pseudo_inverse',
     },
     null,
     2

--- a/src/pages/authenticated/composer/_components/ControlPanel.tsx
+++ b/src/pages/authenticated/composer/_components/ControlPanel.tsx
@@ -174,7 +174,7 @@ const transpilerOptions = {
 
 const mitigationOptions = {
   none: {},
-  ro_pseudo_inverse: { readout: "pseudo_inverse" }
+  ro_pseudo_inverse: { ro_error_mitigation: "pseudo_inverse" }
 }
 
 export const ControlPanelExecution = (props: ControlPanelExecutionProps) => {


### PR DESCRIPTION


## 🐛 Fix: Update mitigation info key from 'readout' to 'ro_error_mitigation'
#120 

### 📋 Summary
Updates the mitigation information key to align with the API specification. The key `readout` has been renamed to `ro_error_mitigation` for readout error mitigation configuration.

### 🔧 Changes Made

**Modified Files:**
- `src/domain/types/Job.ts`
- `src/pages/authenticated/composer/_components/ControlPanel.tsx`

**Changes:**
- Updated mitigation info key from `readout: "pseudo_inverse"` to `ro_error_mitigation: "pseudo_inverse"` in job form defaults
- Updated mitigation options in the composer control panel to use the correct key name
