### PR TITLE
Fix : make job name optional

### DIFF
--- a/src/pages/_components/Input.tsx
+++ b/src/pages/_components/Input.tsx
@@ -7,6 +7,7 @@ export const Input = forwardRef<
   {
     label?: string;
     errorMessage?: string;
+    optional?: boolean;
   } & ComponentPropsWithRef<'input'>
 >(({ label, type, errorMessage, className, ...props }, ref) => {
   const [hidden, setHidden] = useState(true);
@@ -21,7 +22,12 @@ export const Input = forwardRef<
 
   return (
     <div className={clsx('grid', 'gap-1', 'w-full')}>
-      {label && <p className="text-xs">{label}</p>}
+      {label &&
+        <div className={clsx('flex', 'gap-1', 'items-center')}>
+          <p className="text-xs">{label}</p>
+          {props.optional && <span className={clsx('text-sm', 'font-sans', 'italic', 'text-neutral-content')}>optional</span>}
+        </div>
+      }
       {type === 'password' ? (
         <div className={clsx('flex', 'items-center')}>
           <input

--- a/src/pages/authenticated/jobs/_components/JobForm.tsx
+++ b/src/pages/authenticated/jobs/_components/JobForm.tsx
@@ -327,12 +327,14 @@ export const JobForm = (componentProps: JobFormProps) => {
             autoFocus
             placeholder={t('job.form.name_placeholder')}
             label="name"
+            optional
             {...register('name')}
             errorMessage={errors.name && errors.name.message}
           />
           <Input
             placeholder={t('job.form.description_placeholder')}
             label="description"
+            optional
             {...register('description')}
             errorMessage={errors.description && errors.description.message}
           />


### PR DESCRIPTION
Fix #156 

All the points listed in the expected behavior are now satisfied:

 ✅️ Fix Validation Rules
  - Change name field to optional (remove .required())
  - Only treat API-specified required fields (device_id, shots, job_type, job_info) as required
 
✅️ Visual Distinction in UI
   - Add visual indicators for required fields
   - Do not display required marks for optional fields