### PR TITLE
feat: resetform on MFA failure

### DIFF
--- a/src/pages/_hooks/form.ts
+++ b/src/pages/_hooks/form.ts
@@ -13,16 +13,16 @@ export const useFormProcessor = <T extends FieldValues>(
     register,
     handleSubmit,
     formState: { errors },
-    reset, // 変更点 reset追加
+    reset,
   } = useForm<T>({
     resolver: yupResolver(validationRules) as unknown as Resolver<T, any>,
   });
 
   const onSubmit = handleSubmit((data) => {
-    if (processing) return; // ダブルクリック防止
+    if (processing) return;
     setProcessing(true);
     process({ setProcessingFalse: () => setProcessing(false) })(data);
   });
 
-  return { processing, register, onSubmit, errors, reset, }; // 変更点resetも返す
+  return { processing, register, onSubmit, errors, reset, };
 };

--- a/src/pages/auth/login/confirm-mfa/page.tsx
+++ b/src/pages/auth/login/confirm-mfa/page.tsx
@@ -28,7 +28,7 @@ export default function ConfirmMFAPage() {
   const navigate = useNavigate();
   useDocumentTitle(t('signin.confirm.title'));
   const auth = useAuth();
-  const { processing, register, onSubmit, errors, reset, } = useFormProcessor( // 変更点 reset
+  const { processing, register, onSubmit, errors, reset, } = useFormProcessor(
     validationRules(t),
     ({ setProcessingFalse, }) => {
       return (data) => {
@@ -41,14 +41,14 @@ export default function ConfirmMFAPage() {
             }
             toast(result.message, errorToastConfig);
 
-            reset(); // 変更点 reset追加
+            reset();
             setProcessingFalse();
           })
           .catch((error) => {
             const errorMsg = error.message ?? t('common.errors.default');
             toast(errorMsg, errorToastConfig);
 
-            reset(); // 変更点 例外のときもreset追加
+            reset();
             setProcessingFalse();
           });
       };

--- a/src/pages/auth/reset-mfa/mfa-invalidation/page.tsx
+++ b/src/pages/auth/reset-mfa/mfa-invalidation/page.tsx
@@ -11,6 +11,7 @@ import { Spacer } from '@/pages/_components/Spacer';
 import { useDocumentTitle } from '@/pages/_hooks/title';
 import { toast } from 'react-toastify';
 import { errorToastConfig, successToastConfig } from '@/config/toast';
+import { useAuth } from '@/auth/hook';
 
 interface FormInput {
   username: string;
@@ -29,15 +30,19 @@ const validationRules = (t: (key: string) => string): yup.ObjectSchema<FormInput
 export default function ResetMFAPage() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const auth = useAuth();
   useDocumentTitle(t('mfa_reset.title'));
   const { processing, register, onSubmit, errors } = useFormProcessor(
     validationRules(t),
     ({ setProcessingFalse }) => {
       return (data) => {
         resetMfa(data.username, data.password)
-          .then((result) => {
+          .then(async (result) => {
             if (result) {
               toast(t('mfa_reset.alert.success'), successToastConfig);
+              if (auth.signOut){
+                await auth.signOut();
+              }
               navigate('/login');
             } else {
               toast(t('mfa_reset.alert.failure'), errorToastConfig);


### PR DESCRIPTION
Added form reset handling when MFA verification fails.  
If TOTP confirmation is unsuccessful, the form is cleared and processing state is reset to allow immediate re-entry.
