### PR TITLE
fix: deselect on Escape key in composer

### DIFF
--- a/src/pages/authenticated/composer/page.tsx
+++ b/src/pages/authenticated/composer/page.tsx
@@ -138,6 +138,15 @@ export default function Page() {
       'keydown',
       (e) => {
         if (currentFocus === '' || currentFocus === 'panel') return;
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          if (currentFocus === 'observable') {
+            observableCircuitService.selectedGates = [];
+          } else {
+            circuitService.selectedGates = [];
+          }
+          return;
+        }
 
         if (currentFocus === 'observable') {
           if (e.key === 'Delete') {


### PR DESCRIPTION
Change the composer behavior so that pressing the Escape key deselects the current selection.