### PR TITLE
Fix assignmeFix assignment bug in custom gate expansion

### DIFF
--- a/src/pages/authenticated/composer/custom_gates.ts
+++ b/src/pages/authenticated/composer/custom_gates.ts
@@ -125,7 +125,7 @@ export function collectAllGatesFromCustomGate(
     if (gateToAdd._tag === '$custom_gate' && 'customTag' in gateParams) {
       gateToAdd.customTag = gateParams.customTag;
     } else if (isParametrizedGate(gateToAdd) && 'rotationAngle' in gateParams) {
-      gateToAdd.rotationAngle === gateParams.rotationAngle;
+      gateToAdd.rotationAngle = gateParams.rotationAngle;
     }
 
     gates.push(gateToAdd);


### PR DESCRIPTION
Replaced strict equality operator (===) with assignment operator (=) for parametrized gates. Previously, rotation angles were not being applied correctly when expanding custom gates.