### PR TITLE
Show topology when device_info exists (close #235)

### DIFF
--- a/src/pages/authenticated/device/detail/page.tsx
+++ b/src/pages/authenticated/device/detail/page.tsx
@@ -45,12 +45,14 @@ function DeviceDetailPage({ params: { id } }: { params: Params }) {
     return <NotFoundView />;
   }
 
+  const hasDeviceInfo = (device.deviceInfo ?? '').trim() !== '';
+
   return (
     <>
       <Title />
       <Spacer className="h-6" />
       <DeviceDetailBasicInfo {...device} />
-      {device.deviceType === 'QPU' && (
+      {hasDeviceInfo && (
         <div>
           <Spacer className="h-6" />
           <TopologyInfo deviceInfo={device.deviceInfo} />


### PR DESCRIPTION
Closes #235.

Switch topology rendering in Device Detail from device-type-based (QPU) to data-based (device_info present/non-empty). This enables simulator devices with valid device_info to display topology as well.

Validation
- bun run lint passed
- Confirmed local simulator dummy with non-empty device_info renders topology
- Empty/invalid device_info still follows existing error behavior
<img width="1925" height="1051" alt="image" src="https://github.com/user-attachments/assets/0dbd8f6e-7e40-4342-93e4-72abc0498021" />
