### PR TITLE
Support storage-backed device_info in frontend

### DIFF
--- a/public/static_assets/openapi.yaml
+++ b/public/static_assets/openapi.yaml
@@ -61,7 +61,7 @@ paths:
           required: true
           schema:
             type: string
-          example: Kawasaki
+          example: qulacs
       responses:
         '200':
           description: job response
@@ -1000,7 +1000,7 @@ components:
             - barrier
             - reset
         device_info:
-          description: json format calibration_data and n_nodes etc
+          description: Presigned URL for downloading device_info when offloaded to storage; legacy responses may contain json format calibration_data and n_nodes etc.
           type: string
           example: |-
             {
@@ -1474,7 +1474,7 @@ components:
       type: object
       properties:
         id:
-          type: integer
+          type: string
         email:
           type: string
         name:

--- a/public/static_assets/openapi.yaml
+++ b/public/static_assets/openapi.yaml
@@ -1000,20 +1000,9 @@ components:
             - barrier
             - reset
         device_info:
-          description: Presigned URL for downloading device_info when offloaded to storage; legacy responses may contain json format calibration_data and n_nodes etc.
+          description: Presigned URL for downloading device_info.
           type: string
-          example: |-
-            {
-              "n_nodes": 512,
-              "calibration_data": {
-                "qubit_connectivity": ["(1,4)", "(4,5)", "(5,8)"],
-                "t1": {
-                  "0": 55.51,
-                  "1": 37.03,
-                  "2": 57.13
-                }
-              }
-            }
+          example: https://oqtopus-cloud.s3.amazonaws.com/devices/qulacs/device_info.zip?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Expires=1714425600&Signature=abc123def456ghi789jkl%2Fsignature%3D
         calibrated_at:
           description: Parameter available only for `QPU` devices with available calibration data
           type: string
@@ -1036,7 +1025,6 @@ components:
         status: available
         n_pending_jobs: 8
         n_qubits: 39
-        n_nodes: 512
         basis_gates:
           - x
           - 'y'
@@ -1064,18 +1052,7 @@ components:
           - measure
           - barrier
           - reset
-        device_info: |-
-          {
-            "n_nodes": 512,
-            "calibration_data": {
-              "qubit_connectivity": [ "(1,4)", "(4,5)", "(5,8)"],
-              "t1": {
-                "0": 55.51,
-                "1": 37.03,
-                "2": 57.13
-              }
-            }
-          }
+        device_info: https://oqtopus-cloud.s3.amazonaws.com/devices/qulacs/device_info.zip?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Expires=1714425600&Signature=abc123def456ghi789jkl%2Fsignature%3D
         calibrated_at: '2022-10-19T11:45:34Z'
         description: State vector-based quantum circuit simulator
     error.UnauthorizedError:

--- a/src/api/generated/openapi.yaml
+++ b/src/api/generated/openapi.yaml
@@ -61,7 +61,7 @@ paths:
           required: true
           schema:
             type: string
-          example: Kawasaki
+          example: qulacs
       responses:
         '200':
           description: job response
@@ -1000,7 +1000,7 @@ components:
             - barrier
             - reset
         device_info:
-          description: json format calibration_data and n_nodes etc
+          description: Presigned URL for downloading device_info when offloaded to storage; legacy responses may contain json format calibration_data and n_nodes etc.
           type: string
           example: |-
             {
@@ -1474,7 +1474,7 @@ components:
       type: object
       properties:
         id:
-          type: integer
+          type: string
         email:
           type: string
         name:

--- a/src/api/generated/openapi.yaml
+++ b/src/api/generated/openapi.yaml
@@ -1000,20 +1000,9 @@ components:
             - barrier
             - reset
         device_info:
-          description: Presigned URL for downloading device_info when offloaded to storage; legacy responses may contain json format calibration_data and n_nodes etc.
+          description: Presigned URL for downloading device_info.
           type: string
-          example: |-
-            {
-              "n_nodes": 512,
-              "calibration_data": {
-                "qubit_connectivity": ["(1,4)", "(4,5)", "(5,8)"],
-                "t1": {
-                  "0": 55.51,
-                  "1": 37.03,
-                  "2": 57.13
-                }
-              }
-            }
+          example: https://oqtopus-cloud.s3.amazonaws.com/devices/qulacs/device_info.zip?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Expires=1714425600&Signature=abc123def456ghi789jkl%2Fsignature%3D
         calibrated_at:
           description: Parameter available only for `QPU` devices with available calibration data
           type: string
@@ -1036,7 +1025,6 @@ components:
         status: available
         n_pending_jobs: 8
         n_qubits: 39
-        n_nodes: 512
         basis_gates:
           - x
           - 'y'
@@ -1064,18 +1052,7 @@ components:
           - measure
           - barrier
           - reset
-        device_info: |-
-          {
-            "n_nodes": 512,
-            "calibration_data": {
-              "qubit_connectivity": [ "(1,4)", "(4,5)", "(5,8)"],
-              "t1": {
-                "0": 55.51,
-                "1": 37.03,
-                "2": 57.13
-              }
-            }
-          }
+        device_info: https://oqtopus-cloud.s3.amazonaws.com/devices/qulacs/device_info.zip?AWSAccessKeyId=AKIAIOSFODNN7EXAMPLE&Expires=1714425600&Signature=abc123def456ghi789jkl%2Fsignature%3D
         calibrated_at: '2022-10-19T11:45:34Z'
         description: State vector-based quantum circuit simulator
     error.UnauthorizedError:

--- a/src/backend/hook.ts
+++ b/src/backend/hook.ts
@@ -227,11 +227,18 @@ const retrieveDeviceInfo = async (deviceInfo: string | undefined): Promise<strin
   if (!isDeviceInfoUrl(deviceInfo)) return deviceInfo;
 
   return axios
-    .get<string>(deviceInfo, {
-      responseType: 'text',
-      transformResponse: [(data) => data],
+    .get<Blob>(deviceInfo, {
+      responseType: 'blob',
     })
-    .then((res) => res.data);
+    .then(async (res) => {
+      try {
+        const object = await convertZipBlobToObject(res.data);
+        if (object !== undefined) return JSON.stringify(object);
+      } catch {
+        // Fall back to legacy raw JSON responses.
+      }
+      return await res.data.text();
+    });
 };
 
 const convertDeviceResult = async (device: DevicesDeviceInfo): Promise<Device> => ({

--- a/src/backend/hook.ts
+++ b/src/backend/hook.ts
@@ -205,13 +205,13 @@ export const useDeviceAPI = () => {
   const api = useContext(userApiContext);
 
   const getDevices = async (): Promise<Device[]> => {
-    return api.device.listDevices().then((res) => res.data.map(convertDeviceResult));
+    return api.device.listDevices().then((res) => Promise.all(res.data.map(convertDeviceResult)));
   };
 
   const getDevice = async (id: string): Promise<Device | null> => {
-    return api.device.getDevice(id).then((res) => {
+    return api.device.getDevice(id).then(async (res) => {
       if (res.status === 200) {
-        return convertDeviceResult(res.data);
+        return await convertDeviceResult(res.data);
       }
       return null;
     });
@@ -220,7 +220,21 @@ export const useDeviceAPI = () => {
   return { getDevices, getDevice };
 };
 
-const convertDeviceResult = (device: DevicesDeviceInfo): Device => ({
+const isDeviceInfoUrl = (deviceInfo: string): boolean => /^https?:\/\//.test(deviceInfo);
+
+const retrieveDeviceInfo = async (deviceInfo: string | undefined): Promise<string> => {
+  if (!deviceInfo) return '';
+  if (!isDeviceInfoUrl(deviceInfo)) return deviceInfo;
+
+  return axios
+    .get<string>(deviceInfo, {
+      responseType: 'text',
+      transformResponse: [(data) => data],
+    })
+    .then((res) => res.data);
+};
+
+const convertDeviceResult = async (device: DevicesDeviceInfo): Promise<Device> => ({
   id: device.device_id,
   deviceType: device.device_type,
   status: device.status,
@@ -229,7 +243,7 @@ const convertDeviceResult = (device: DevicesDeviceInfo): Device => ({
   nQubits: device.n_qubits ?? 0, // TODO: fix invalid oas schema (nullable: should be false)
   basisGates: device.basis_gates,
   supportedInstructions: device.supported_instructions,
-  deviceInfo: device.device_info ?? '', // TODO: fix invalid oas schema (nullable: should be false)
+  deviceInfo: await retrieveDeviceInfo(device.device_info), // TODO: fix invalid oas schema (nullable: should be false)
   calibratedAt: device.calibrated_at ?? '', // TODO: fix invalid oas schema (nullable: should be false)
   description: device.description,
 });


### PR DESCRIPTION
## Summary

Support storage-backed `device_info` in frontend.

- load `device_info` from presigned download URLs
- resolve `device_info.zip` for display

Related issue:
- oqtopus-team/oqtopus-cloud#484

Depends on:
- oqtopus-team/oqtopus-cloud#485