### PR TITLE
fix: make form input text readable in dark mode

### DIFF
--- a/src/pages/globals.css
+++ b/src/pages/globals.css
@@ -32,6 +32,17 @@
   th {
     @apply text-xs;
   }
+
+  input:not([type='checkbox']):not([type='radio']):not([type='range']):not([type='file']),
+  textarea,
+  select {
+    @apply bg-base-card text-base-content;
+  }
+
+  input::placeholder,
+  textarea::placeholder {
+    @apply text-neutral-content;
+  }
 }
 
 @layer components {

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,6 @@
 :root {
+    color-scheme: light;
+
     /* Primitive colors */
     --primary: 72 135 250;
     --primary-content: 255 255 255;
@@ -50,6 +52,8 @@
 }
 
 .dark {
+    color-scheme: dark;
+
     /* Primitive colors */
     --primary: 91 155 255;
     --primary-content: 10 10 10;


### PR DESCRIPTION
## Summary

Form inputs rendered dark text on a dark background in dark mode, making the
typed value (e.g. the TOTP code on the auth screen) unreadable. This applies
theme-aware colors so input text stays legible in both light and dark modes.

## Changes

- **`src/pages/globals.css`**: apply `bg-base-card` / `text-base-content` to
  `input` (excluding `checkbox`, `radio`, `range`, `file`), `textarea`, and
  `select`, and `text-neutral-content` to their placeholders
- **`src/style.css`**: set `color-scheme: light` on `:root` and
  `color-scheme: dark` on `.dark` so native form controls follow the active theme

## Screenshots

### Before
<img width="378" height="306" alt="スクリーンショット 2026-07-13 14 55 22" src="https://github.com/user-attachments/assets/3d29345f-fcb4-43f9-9e02-abb34180023c" />

### After
<img width="345" height="293" alt="スクリーンショット 2026-07-13 14 32 13" src="https://github.com/user-attachments/assets/6b89177b-fe8e-4e18-b8d8-62e609f25825" />