### PR TITLE
Feat: Add reset initial password page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import AuthLayout from '@/pages/auth/layout';
 import LoginLayout from '@/pages/auth/login/login/layout';
 import LoginPage from '@/pages/auth/login/login/page';
 import ConfirmMFAPage from '@/pages/auth/login/confirm-mfa/page';
+import NewPasswordPage from '@/pages/auth/login/new-password/page';
 import SignUpPage from '@/pages/auth/signup/signup/page';
 import ConfirmSetupMFAPage from '@/pages/auth/signup/confirm/page';
 import SetupMFAPage from '@/pages/auth/signup/mfa/page';
@@ -47,6 +48,7 @@ export const App: React.FunctionComponent = () => {
                   <Route path="login" element={<LoginPage />} />
                 </Route>
                 <Route path="confirm-mfa" element={<ConfirmMFAPage />} />
+                <Route path="new-password" element={<NewPasswordPage />} />
               </Route>
 
               <Route /* signup flow */>

--- a/src/auth/Provider.test.tsx
+++ b/src/auth/Provider.test.tsx
@@ -14,6 +14,7 @@ vi.mock('aws-amplify', () => ({
     currentAuthenticatedUser: vi.fn(),
     currentSession: vi.fn(),
     signIn: vi.fn(),
+    completeNewPassword: vi.fn(),
     signOut: vi.fn(),
     forgotPassword: vi.fn(),
     forgotPasswordSubmit: vi.fn(),
@@ -43,6 +44,7 @@ const mockAuth = Auth as unknown as {
   currentAuthenticatedUser: Mock;
   currentSession: Mock;
   signIn: Mock;
+  completeNewPassword: Mock;
   signOut: Mock;
   forgotPassword: Mock;
   forgotPasswordSubmit: Mock;
@@ -233,6 +235,107 @@ describe('Auth Functions', () => {
         success: false,
         message: 'Invalid credentials',
       });
+    });
+
+    it('flags NEW_PASSWORD_REQUIRED as a distinct challenge and records it as pending', async () => {
+      mockAuth.signIn.mockResolvedValue({
+        username: 'testuser',
+        challengeName: 'NEW_PASSWORD_REQUIRED',
+      });
+
+      const { result } = renderHook(() => useContext(AuthContext), {
+        wrapper: TestWrapper,
+      });
+
+      await waitFor(() => expect(result.current.initialized).toBe(true));
+
+      let response: { success: boolean; message: string } | undefined;
+      await act(async () => {
+        response = await result.current.signIn('testuser', 'temp-pass');
+      });
+
+      expect(response).toEqual({ success: false, message: 'signin.new_password_required' });
+      expect(result.current.pendingChallenge).toBe('NEW_PASSWORD_REQUIRED');
+    });
+  });
+
+  describe('completeNewPassword', () => {
+    it('carries the pending CognitoUser from signIn and clears the challenge once the session is established', async () => {
+      // Drive the real pending state first: signIn stashes this CognitoUser and
+      // sets pendingChallenge, then completeNewPassword must consume that same
+      // user and clear the challenge. Starting from null (as a bare call would)
+      // would let a removed setPendingChallenge(null) pass unnoticed.
+      const challengeUser = { username: 'testuser', challengeName: 'NEW_PASSWORD_REQUIRED' };
+      mockAuth.signIn.mockResolvedValue(challengeUser);
+      // No challengeName on the resolved user => sign-in is complete.
+      mockAuth.completeNewPassword.mockResolvedValue({ username: 'testuser' });
+
+      const { result } = renderHook(() => useContext(AuthContext), {
+        wrapper: TestWrapper,
+      });
+      await waitFor(() => expect(result.current.initialized).toBe(true));
+
+      await act(async () => {
+        await result.current.signIn('testuser', 'temp-pass');
+      });
+      expect(result.current.pendingChallenge).toBe('NEW_PASSWORD_REQUIRED');
+
+      let response: { success: boolean; message: string } | undefined;
+      await act(async () => {
+        response = await result.current.completeNewPassword('NewPassw0rd!');
+      });
+
+      // The exact CognitoUser captured by signIn is what gets completed.
+      expect(mockAuth.completeNewPassword).toHaveBeenCalledWith(challengeUser, 'NewPassw0rd!');
+      expect(response).toEqual({ success: true, message: '' });
+      expect(result.current.pendingChallenge).toBeNull();
+    });
+
+    it('routes to TOTP entry when a SOFTWARE_TOKEN_MFA challenge follows', async () => {
+      mockAuth.completeNewPassword.mockResolvedValue({
+        username: 'testuser',
+        challengeName: 'SOFTWARE_TOKEN_MFA',
+      });
+
+      const { result } = renderHook(() => useContext(AuthContext), {
+        wrapper: TestWrapper,
+      });
+      await waitFor(() => expect(result.current.initialized).toBe(true));
+
+      const response = await result.current.completeNewPassword('NewPassw0rd!');
+      expect(response).toEqual({ success: true, message: 'signin.totp_required' });
+    });
+
+    it('reports the dedicated "sign in again" result on an unsupported follow-up challenge (e.g. MFA_SETUP)', async () => {
+      // The password is already accepted at this point, so this is not a
+      // password-change failure -- the caller routes back to /login.
+      mockAuth.completeNewPassword.mockResolvedValue({
+        username: 'testuser',
+        challengeName: 'MFA_SETUP',
+      });
+
+      const { result } = renderHook(() => useContext(AuthContext), {
+        wrapper: TestWrapper,
+      });
+      await waitFor(() => expect(result.current.initialized).toBe(true));
+
+      const response = await result.current.completeNewPassword('NewPassw0rd!');
+      expect(response).toEqual({
+        success: false,
+        message: 'signin.new_password.additional_mfa_required',
+      });
+    });
+
+    it('returns the error message when completeNewPassword rejects', async () => {
+      mockAuth.completeNewPassword.mockRejectedValue(new Error('Password does not conform'));
+
+      const { result } = renderHook(() => useContext(AuthContext), {
+        wrapper: TestWrapper,
+      });
+      await waitFor(() => expect(result.current.initialized).toBe(true));
+
+      const response = await result.current.completeNewPassword('weak');
+      expect(response).toEqual({ success: false, message: 'Password does not conform' });
     });
   });
 

--- a/src/auth/Provider.tsx
+++ b/src/auth/Provider.tsx
@@ -12,8 +12,14 @@ export interface UseAuth {
   username: string;
   qrcode: string;
   email: string;
+  // Name of a sign-in challenge currently awaiting a follow-up call (e.g.
+  // 'NEW_PASSWORD_REQUIRED'), or null. Screens that complete a challenge use
+  // this to confirm the pending CognitoUser still exists in this provider
+  // instance -- it is lost on a full reload, unlike router history state.
+  pendingChallenge: string | null;
   getCurrentIdToken: () => Promise<string>;
   signIn: (username: string, password: string) => Promise<Result>;
+  completeNewPassword: (newPassword: string) => Promise<Result>;
   signOut: () => Promise<Result>;
   signUp: (username: string, password: string) => Promise<Result>;
   confirmSignUp: (verificationCode: string) => Promise<Result>;
@@ -48,6 +54,7 @@ const useProvideAuth = (): UseAuth => {
   const [password, setPassword] = useState('');
   const [qrcode, setQRCode] = useState('');
   const [resultUser, setResultUser] = useState({});
+  const [pendingChallenge, setPendingChallenge] = useState<string | null>(null);
   const [email, setEmail] = useState('');
 
   const { t } = useTranslation();
@@ -93,15 +100,75 @@ const useProvideAuth = (): UseAuth => {
       setResultUser(result);
       setUsername(result.username);
       setPassword(result.password);
-      const hasChallenge = Object.prototype.hasOwnProperty.call(result, 'challengeName');
       setIsAuthenticated(false);
       setInitialized(true);
+      // A user provisioned with a temporary password (e.g. after a pool
+      // restore / admin-created account) must set a new password before any
+      // MFA step. This is a distinct challenge from the TOTP one, so surface it
+      // separately and let the login page route to the set-new-password screen.
+      if (result.challengeName === 'NEW_PASSWORD_REQUIRED') {
+        setPendingChallenge('NEW_PASSWORD_REQUIRED');
+        return { success: false, message: 'signin.new_password_required' };
+      }
+      setPendingChallenge(null);
+      const hasChallenge = Object.prototype.hasOwnProperty.call(result, 'challengeName');
       if (!hasChallenge) {
         return { success: false, message: 'signup.confirm.form.mfa_setup_request' };
       }
       return { success: true, message: '' };
     } catch (error) {
+      setPendingChallenge(null);
       const errorMessage = (error as Error).message ?? 'signin.errors.authentication_failed';
+      return {
+        success: false,
+        message: errorMessage,
+      };
+    }
+  };
+
+  // Completes the NEW_PASSWORD_REQUIRED challenge raised by signIn for a user
+  // that still has a temporary password. `resultUser` is the CognitoUser
+  // captured by signIn.
+  //
+  // Auth.completeNewPassword resolves in more than one terminal state: it may
+  // establish the session outright, or return the CognitoUser bearing a further
+  // challenge (SOFTWARE_TOKEN_MFA for an already-enrolled user, MFA_SETUP for a
+  // required-MFA pool). Only when the session is actually established can the
+  // next screen call Auth.currentAuthenticatedUser(), so distinguish the cases
+  // and tell the caller where to go via the message:
+  //   - success, message ''                    -> session established, enroll MFA
+  //   - success, message 'signin.totp_required' -> TOTP challenge, go enter code
+  //   - failure                                 -> unsupported/failed
+  const completeNewPassword = async (newPassword: string): Promise<Result> => {
+    try {
+      const user = await Auth.completeNewPassword(resultUser, newPassword);
+      setResultUser(user);
+      setIsAuthenticated(false);
+      setInitialized(true);
+
+      const nextChallenge: string | undefined = (user as { challengeName?: string })?.challengeName;
+      if (!nextChallenge) {
+        // Session established. The pending challenge is resolved.
+        setPendingChallenge(null);
+        return { success: true, message: '' };
+      }
+      if (nextChallenge === 'SOFTWARE_TOKEN_MFA') {
+        // Already-enrolled user: resultUser now holds this challenge, which the
+        // existing confirm-mfa screen consumes via confirmSignIn.
+        setPendingChallenge(null);
+        return { success: true, message: 'signin.totp_required' };
+      }
+      // MFA_SETUP / SMS_MFA / anything else: there is no challenge-driven
+      // enrollment path here (and an OPTIONAL-MFA pool never raises these). The
+      // NEW password has ALREADY been accepted by Cognito at this point, so this
+      // is not a password-change failure and the challenge is spent -- keeping
+      // the user on the new-password form would be both wrong and unrecoverable.
+      // Return a dedicated result so the caller sends them back to sign in.
+      setPendingChallenge(null);
+      return { success: false, message: 'signin.new_password.additional_mfa_required' };
+    } catch (error) {
+      // Leave pendingChallenge intact so the user can correct and retry.
+      const errorMessage = (error as Error).message ?? 'signin.errors.password_change_failed';
       return {
         success: false,
         message: errorMessage,
@@ -409,8 +476,10 @@ const useProvideAuth = (): UseAuth => {
     username,
     qrcode,
     email,
+    pendingChallenge,
     getCurrentIdToken,
     signIn,
+    completeNewPassword,
     signOut,
     signUp,
     confirmSignUp,

--- a/src/i18n/en/forgot_password.ts
+++ b/src/i18n/en/forgot_password.ts
@@ -25,7 +25,7 @@ export default {
         password_uppercase: 'Please include capital letters',
         password_number: 'Please include numbers',
         password_special: 'Please include special characters (^$*.11（?-"！@#％＆人>く.L~\'+=)',
-        password_min: 'Please enter at least 8 characters',
+        password_min: 'Please enter at least 12 characters',
         confirm_password_enter: 'Please enter your confirmation password',
         confirm_password_mismatch: 'Password does not match',
         code_enter: 'Please enter verification code',

--- a/src/i18n/en/signin.ts
+++ b/src/i18n/en/signin.ts
@@ -22,6 +22,30 @@ export default {
     button: 'Send',
     api_token_reissued: 'API token has been reissued.',
   },
+  new_password: {
+    title: 'Set a new password',
+    description:
+      'Your account is using a temporary password. Please set a new password to continue.',
+    form: {
+      password: 'New password',
+      password_explanation:
+        'Use at least 12 characters, including uppercase and lowercase letters, a number, and a symbol.',
+      confirm_password: 'New password (confirm)',
+      error_message: {
+        password_enter: 'Please enter your password',
+        password_lowercase: 'Please include a lowercase letter',
+        password_uppercase: 'Please include an uppercase letter',
+        password_number: 'Please include a number',
+        password_special: 'Please include a symbol',
+        password_min: 'Please enter at least 12 characters',
+        confirm_password_enter: 'Please enter your confirmation password',
+        confirm_password_mismatch: 'Passwords do not match',
+      },
+    },
+    button: 'Set password',
+    additional_mfa_required:
+      'Your password has been changed. An additional authentication step is required, so please sign in again.',
+  },
   errors: {
     authentication_failed: 'Authentication failed',
     logout_failed: 'Logout failed',

--- a/src/i18n/ja/forgot_password.ts
+++ b/src/i18n/ja/forgot_password.ts
@@ -25,7 +25,7 @@ export default {
         password_uppercase: '大文字を含めてください',
         password_number: '数字を含めてくださいい',
         password_special: '特殊文字（^$*.11（?-"！@#％＆人>く.L~\'+=）を含めてください。',
-        password_min: '8文字以上で入力してください',
+        password_min: '12文字以上で入力してください',
         confirm_password_enter: '確認用パスワードを入力してください',
         confirm_password_mismatch: 'パスワードが合致しません',
         code_enter: '検証コードを入力してください',

--- a/src/i18n/ja/signin.ts
+++ b/src/i18n/ja/signin.ts
@@ -24,6 +24,29 @@ export default {
     button: '送信する',
     api_token_reissued: 'APIトークンを再発行しました。',
   },
+  new_password: {
+    title: '新しいパスワードの設定',
+    description:
+      'アカウントは仮パスワードの状態です。続行するには新しいパスワードを設定してください。',
+    form: {
+      password: '新しいパスワード',
+      password_explanation: '12文字以上で、大文字・小文字・数字・記号をそれぞれ含めてください。',
+      confirm_password: '新しいパスワード（確認）',
+      error_message: {
+        password_enter: 'パスワードを入力してください',
+        password_lowercase: '小文字を含めてください',
+        password_uppercase: '大文字を含めてください',
+        password_number: '数字を含めてください',
+        password_special: '記号を含めてください',
+        password_min: '12文字以上で入力してください',
+        confirm_password_enter: '確認用パスワードを入力してください',
+        confirm_password_mismatch: 'パスワードが一致しません',
+      },
+    },
+    button: 'パスワードを設定する',
+    additional_mfa_required:
+      'パスワードを変更しました。追加の認証手続きが必要なため、もう一度サインインしてください。',
+  },
   errors: {
     authentication_failed: '認証に失敗しました。',
     logout_failed: 'ログアウトに失敗しました。',

--- a/src/pages/auth/login/login/page.tsx
+++ b/src/pages/auth/login/login/page.tsx
@@ -42,6 +42,14 @@ export default function LoginPage() {
             navigate('/confirm-mfa');
             return;
           }
+          if (message === 'signin.new_password_required') {
+            // Temporary-password user (e.g. after a pool restore): send them to
+            // set a new password before the MFA step. Not an error -> no toast.
+            // The screen guards on the provider's pending challenge, not on any
+            // navigation state, so nothing needs to be passed here.
+            navigate('/new-password');
+            return;
+          }
           toast(t(message), errorToastConfig);
           if (message === 'signup.confirm.form.mfa_setup_request') {
             // if MFA is not set, execute MFA reset flow

--- a/src/pages/auth/login/new-password/page.tsx
+++ b/src/pages/auth/login/new-password/page.tsx
@@ -1,0 +1,134 @@
+import { useLayoutEffect } from 'react';
+import * as yup from 'yup';
+import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
+import { useAuth } from '@/auth/hook';
+import { useNavigate } from 'react-router';
+import { Button } from '@/pages/_components/Button';
+import { Input } from '@/pages/_components/Input';
+import { FormTitle } from '../../_components/FormTitle';
+import { useFormProcessor } from '@/pages/_hooks/form';
+import { Spacer } from '@/pages/_components/Spacer';
+import { useDocumentTitle } from '@/pages/_hooks/title';
+import { toast } from 'react-toastify';
+import { errorToastConfig, infoToastConfig } from '@/config/toast';
+import {
+  createPasswordConfirmSchema,
+  createPasswordSchema,
+} from '@/config/validation/passwordSchemas';
+
+interface FormInput {
+  password: string;
+  confirm_password: string;
+}
+
+const validationRules = (t: (key: string) => string): yup.ObjectSchema<FormInput> =>
+  yup.object({
+    password: createPasswordSchema(
+      {
+        required: t('signin.new_password.form.error_message.password_enter'),
+        lowercase: t('signin.new_password.form.error_message.password_lowercase'),
+        uppercase: t('signin.new_password.form.error_message.password_uppercase'),
+        number: t('signin.new_password.form.error_message.password_number'),
+        special: t('signin.new_password.form.error_message.password_special'),
+        min: t('signin.new_password.form.error_message.password_min'),
+      },
+      12
+    ),
+    confirm_password: createPasswordConfirmSchema('password', {
+      required: t('signin.new_password.form.error_message.confirm_password_enter'),
+      mismatch: t('signin.new_password.form.error_message.confirm_password_mismatch'),
+    }),
+  });
+
+export default function NewPasswordPage() {
+  const { t } = useTranslation();
+  useDocumentTitle(t('signin.new_password.title'));
+  const auth = useAuth();
+  const navigate = useNavigate();
+
+  // This screen is only valid while signIn's NEW_PASSWORD_REQUIRED challenge is
+  // pending in the auth provider (which holds the CognitoUser that
+  // completeNewPassword needs). On a full reload the provider re-mounts and that
+  // pending user is gone, so redirect to login rather than fail on submit.
+  // Checked once on mount: later clearing of pendingChallenge (on success) must
+  // not retrigger this and race the success navigation.
+  useLayoutEffect(() => {
+    if (auth.pendingChallenge !== 'NEW_PASSWORD_REQUIRED') {
+      navigate('/login');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const { processing, register, onSubmit, errors } = useFormProcessor(
+    validationRules(t),
+    ({ setProcessingFalse }) => {
+      return (data) => {
+        auth
+          .completeNewPassword(data.password)
+          .then((result) => {
+            if (result.success) {
+              // 'signin.totp_required' -> the user is already MFA-enrolled, go
+              // enter the code; otherwise the session is established and we
+              // enroll a fresh TOTP device.
+              navigate(result.message === 'signin.totp_required' ? '/confirm-mfa' : '/mfa');
+              return;
+            }
+            if (result.message === 'signin.new_password.additional_mfa_required') {
+              // Password was accepted but Cognito raised an unsupported extra
+              // challenge; the challenge is spent, so re-entering here cannot
+              // recover. Inform the user and send them back to sign in.
+              toast(t(result.message), infoToastConfig);
+              navigate('/login');
+              return;
+            }
+            toast(t(result.message), errorToastConfig);
+            setProcessingFalse();
+          })
+          .catch((error) => {
+            const errorMsg = error.message ?? t('common.errors.default');
+            toast(errorMsg, errorToastConfig);
+          });
+      };
+    }
+  );
+
+  return (
+    <div className={clsx('w-[300px]', 'pt-8', 'text-sm')}>
+      <FormTitle>{t('signin.new_password.title')}</FormTitle>
+      <Spacer className="h-4" />
+      <p className={clsx('text-xs', 'leading-[1.8]')}>{t('signin.new_password.description')}</p>
+      <Spacer className="h-6" />
+      <form noValidate onSubmit={onSubmit}>
+        <Input
+          autoFocus
+          type={'password'}
+          autoComplete="new-password"
+          placeholder="Enter Password"
+          label={t('signin.new_password.form.password')}
+          errorMessage={errors.password?.message}
+          {...register('password')}
+          className={clsx('bg-base-card')}
+        />
+        <Spacer className="h-2.5" />
+        <p className={clsx('text-xs', 'leading-[1.8]', 'text-neutral-content')}>
+          {t('signin.new_password.form.password_explanation')}
+        </p>
+        <Spacer className="h-3" />
+        <Input
+          type={'password'}
+          autoComplete="new-password"
+          placeholder="Enter Confirm Password"
+          label={t('signin.new_password.form.confirm_password')}
+          errorMessage={errors.confirm_password?.message}
+          {...register('confirm_password')}
+          className={clsx('bg-base-card')}
+        />
+        <Spacer className="h-5" />
+        <Button type="submit" color="secondary" loading={processing}>
+          {t('signin.new_password.button')}
+        </Button>
+      </form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Problem

The frontend auth flow branches on the ChallengeName in Cognito's sign-in response, but it does not handle NEW_PASSWORD_REQUIRED (the challenge returned after logging in with a temporary/initial password). Any challenge was treated the same and routed to the MFA (TOTP) entry screen, so a temporary-password user was sent to MFA without first changing their password — and got stuck.

Consequently, when a user cannot reset their own password and the operations team resets it on their behalf, that user has no way to sign in.

## Fix

Detect NEW_PASSWORD_REQUIRED distinctly and route the user to a new "set a new password" screen; once the password is set, continue to TOTP enrollment and then the dashboard.

## Changes

- signIn distinguishes NEW_PASSWORD_REQUIRED from the TOTP challenge.
- Add completeNewPassword, which inspects the follow-up challenge and routes accordingly (session established → MFA setup; SOFTWARE_TOKEN_MFA → code entry; unsupported → sign in again).
- Add the /new-password screen, guarded by a pending-challenge check in the auth provider (survives a page reload).
- Fix stale password-rule messages (min length 8 → 12).